### PR TITLE
Exclude Claude tooling scripts from language statistics.

### DIFF
--- a/.claude/skills/tiny-blocks-create/assets/config/.gitattributes
+++ b/.claude/skills/tiny-blocks-create/assets/config/.gitattributes
@@ -2,6 +2,9 @@
 
 *.php text diff=php
 
+# Keep Claude tooling scripts out of GitHub's language statistics
+/.claude/**/*.py linguist-vendored
+
 # Dev-only, excluded from the Packagist tarball
 /.github             export-ignore
 /tests               export-ignore

--- a/.claude/skills/tiny-blocks-create/assets/config/.gitignore
+++ b/.claude/skills/tiny-blocks-create/assets/config/.gitignore
@@ -26,3 +26,7 @@ infection.log
 Thumbs.db
 .DS_Store
 Desktop.ini
+
+# Cache from .claude Python hooks
+__pycache__/
+*.pyc

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 
 *.php text diff=php
 
+# Keep Claude tooling scripts out of GitHub's language statistics
+/.claude/**/*.py linguist-vendored
+
 # Dev-only, excluded from the Packagist tarball
 /.github             export-ignore
 /tests               export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ infection.log
 Thumbs.db
 .DS_Store
 Desktop.ini
+
+# Cache from .claude Python hooks
+__pycache__/
+*.pyc

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
         "tiny-blocks/encoder": "^4.0"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "^2.51",
-        "infection/infection": "^0.32",
-        "phpstan/phpstan": "^2.1",
+        "ergebnis/composer-normalize": "^2.52",
+        "infection/infection": "^0.33",
+        "phpstan/phpstan": "^2.2",
         "phpunit/phpunit": "^13.1",
         "squizlabs/php_codesniffer": "^4.0"
     },


### PR DESCRIPTION
Mark .claude Python scripts as linguist-vendored so GitHub Linguist detects the repository as PHP, and ignore __pycache__ and *.pyc to keep hook caches out of the index. The same change lands in the tiny-blocks-create scaffold templates. Dependency floors for composer-normalize, infection, and phpstan are bumped in the same commit.

> Please follow the [contributing guidelines](https://github.com/tiny-blocks/tiny-blocks/blob/main/CONTRIBUTING.md).

## Summary

What this pull request does.

## Related issue

Closes #...

## Checklist

- [ ] Tests added or updated.
- [ ] Documentation updated when applicable.
- [ ] `composer review` passes.
- [ ] `composer tests` passes.
